### PR TITLE
Remove .title() from round.map_name

### DIFF
--- a/yogsite/templates/rounds/rounds.html
+++ b/yogsite/templates/rounds/rounds.html
@@ -60,7 +60,7 @@
 										{% if round.map_name %}
 											href="?query={{ round.map_name | quote_plus }}"
 										{% endif %}
-										class="tag is-medium is-primary">{{ (round.map_name or "None").title() }}
+										class="tag is-medium is-primary">{{ (round.map_name or "None") }}
 									</a>
 								</td>
 


### PR DESCRIPTION
Doesn't work with NVS Gax (turns it into "Nvs Gax") and all our map names are already in proper form as to how they should show up.